### PR TITLE
Make container-like testing the default

### DIFF
--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -531,17 +531,6 @@ function _containerlike_diff(p::P, q::P) where {P}
     return build_tangent(P, diffed_fields...)
 end
 
-# for _P in [
-#     UnitRange, Transpose, Adjoint, SubArray, Base.RefValue, LazyString, Diagonal, Xoshiro,
-#     StepRange, UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular,
-#     Base.OneTo, Complex, CartesianIndices, CartesianIndex, LinearIndices,
-#     Base.Pairs, Base.Slice, Rational, UniformScaling, PermutedDimsArray, SymTridiagonal,
-#     Symmetric, Bidiagonal,
-# ]
-#     @eval _add_to_primal(p::$_P, t) = _containerlike_add_to_primal(p, t)
-#     @eval _diff(p::P, q::P) where {P<:$_P} = _containerlike_diff(p, q)
-# end
-
 @generated function might_be_active(::Type{P}) where {P}
     tangent_type(P) == NoTangent && return :(return false)
     Base.issingletontype(P) && return :(return false)

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -486,8 +486,12 @@ _add_to_primal(x::Tuple, t::Tuple) = _map(_add_to_primal, x, t)
 _add_to_primal(x::NamedTuple, t::NamedTuple) = _map(_add_to_primal, x, t)
 _add_to_primal(x, ::Tangent{NamedTuple{(), Tuple{}}}) = x
 
-function _containerlike_add_to_primal(p::T, t::Union{Tangent, MutableTangent}) where {T}
-    tmp = map(fieldnames(T)) do f
+function _add_to_primal(p::P, t::T) where {P, T<:Union{Tangent, MutableTangent}}
+    Tt = tangent_type(P)
+    if Tt != typeof(t)
+        throw(ArgumentError("p of type $P has tangent_type $Tt, but t is of type $T"))
+    end
+    tmp = map(fieldnames(P)) do f
         tf = getfield(t.fields, f)
         isdefined(p, f) && is_init(tf) && return _add_to_primal(getfield(p, f), tf.tangent) 
         !isdefined(p, f) && !is_init(tf) && return FieldUndefined()
@@ -500,18 +504,15 @@ end
     _diff(p::P, q::P) where {P}
 
 Required for testing.
-_Not_ currently defined by default.
-`_containerlike_diff` is potentially what you want to target when implementing for
-a particular primal-tangent pair.
 
 Computes the difference between `p` and `q`, which _must_ be of the same type, `P`.
 Returns a tangent of type `tangent_type(P)`.
 """
-function _diff(::P, ::P) where {P}
+function _diff(p::P, q::P) where {P}
     tangent_type(P) === NoTangent && return NoTangent()
     T = Tangent{NamedTuple{(), Tuple{}}}
     tangent_type(P) === T && return T((;))
-    error("tangent_type(P) is not NoTangent, and no other method provided")
+    return _containerlike_diff(p, q)
 end
 _diff(p::P, q::P) where {P<:IEEEFloat} = p - q
 function _diff(p::P, q::P) where {V, N, P<:Array{V, N}}
@@ -530,16 +531,16 @@ function _containerlike_diff(p::P, q::P) where {P}
     return build_tangent(P, diffed_fields...)
 end
 
-for _P in [
-    UnitRange, Transpose, Adjoint, SubArray, Base.RefValue, LazyString, Diagonal, Xoshiro,
-    StepRange, UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular,
-    Base.OneTo, Complex, CartesianIndices, CartesianIndex, LinearIndices,
-    Base.Pairs, Base.Slice, Rational, UniformScaling, PermutedDimsArray, SymTridiagonal,
-    Symmetric, Bidiagonal,
-]
-    @eval _add_to_primal(p::$_P, t) = _containerlike_add_to_primal(p, t)
-    @eval _diff(p::P, q::P) where {P<:$_P} = _containerlike_diff(p, q)
-end
+# for _P in [
+#     UnitRange, Transpose, Adjoint, SubArray, Base.RefValue, LazyString, Diagonal, Xoshiro,
+#     StepRange, UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular,
+#     Base.OneTo, Complex, CartesianIndices, CartesianIndex, LinearIndices,
+#     Base.Pairs, Base.Slice, Rational, UniformScaling, PermutedDimsArray, SymTridiagonal,
+#     Symmetric, Bidiagonal,
+# ]
+#     @eval _add_to_primal(p::$_P, t) = _containerlike_add_to_primal(p, t)
+#     @eval _diff(p::P, q::P) where {P<:$_P} = _containerlike_diff(p, q)
+# end
 
 @generated function might_be_active(::Type{P}) where {P}
     tangent_type(P) == NoTangent && return :(return false)

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -497,7 +497,7 @@ function _add_to_primal(p::P, t::T) where {P, T<:Union{Tangent, MutableTangent}}
         !isdefined(p, f) && !is_init(tf) && return FieldUndefined()
         throw(error("unable to handle undefined-ness"))
     end
-    return T(filter(!=(FieldUndefined()), tmp)...)
+    return P(filter(!=(FieldUndefined()), tmp)...)
 end
 
 """

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -523,10 +523,10 @@ function Base.:(==)(a::TypeStableMutableStruct, b::TypeStableMutableStruct)
     return equal_field(a, b, :a) && equal_field(a, b, :b)
 end
 
-for T in [Foo, StructFoo, MutableFoo, TypeStableMutableStruct]
-    @eval Taped._add_to_primal(p::$T, t) = Taped._containerlike_add_to_primal(p, t)
-    @eval Taped._diff(p::$T, q::$T) = Taped._containerlike_diff(p, q)
-end
+# for T in [Foo, StructFoo, MutableFoo, TypeStableMutableStruct]
+#     @eval Taped._add_to_primal(p::$T, t) = Taped._containerlike_add_to_primal(p, t)
+#     @eval Taped._diff(p::$T, q::$T) = Taped._containerlike_diff(p, q)
+# end
 
 
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -523,11 +523,6 @@ function Base.:(==)(a::TypeStableMutableStruct, b::TypeStableMutableStruct)
     return equal_field(a, b, :a) && equal_field(a, b, :b)
 end
 
-# for T in [Foo, StructFoo, MutableFoo, TypeStableMutableStruct]
-#     @eval Taped._add_to_primal(p::$T, t) = Taped._containerlike_add_to_primal(p, t)
-#     @eval Taped._diff(p::$T, q::$T) = Taped._containerlike_diff(p, q)
-# end
-
 
 
 #

--- a/test/integration_testing/distributions.jl
+++ b/test/integration_testing/distributions.jl
@@ -1,19 +1,19 @@
 # Functionality to make testing straightforward.
-for T in [
-    Arcsine, Beta, BetaPrime, Biweight, Cauchy, Chi, Chisq, Chernoff, Cosine, Epanechnikov,
-    Erlang, Exponential, FDist, Frechet, Gamma, GeneralizedExtremeValue, GeneralizedPareto,
-    Gumbel, InverseGaussian, JohnsonSU, Kumaraswamy, Laplace, Levy, Lindley, Logistic,
-    LogitNormal, LogNormal, LogUniform, NoncentralBeta, NoncentralChisq, NoncentralF,
-    NoncentralT, Normal, NormalInverseGaussian, Pareto, PGeneralizedGaussian, Rayleigh,
-    Rician, Semicircle, SkewedExponentialPower, SkewNormal, SymTriangularDist, TDist,
-    TriangularDist, Triweight, Uniform, VonMises, Weibull, MvNormal, Distributions.Zeros,
-    Distributions.ScalMat, Distributions.PDiagMat, PDMat, Cholesky, MvNormalCanon,
-    MvLogitNormal, MvLogNormal, Product, MatrixBeta, Wishart, MatrixFDist, LKJ,
-    Symmetric, MatrixNormal, InverseWishart, MatrixTDist,
-]
-    @eval Taped._add_to_primal(p::$T, t) = Taped._containerlike_add_to_primal(p, t)
-    @eval Taped._diff(p::$T, q::$T) = Taped._containerlike_diff(p, q)
-end
+# for T in [
+#     Arcsine, Beta, BetaPrime, Biweight, Cauchy, Chi, Chisq, Chernoff, Cosine, Epanechnikov,
+#     Erlang, Exponential, FDist, Frechet, Gamma, GeneralizedExtremeValue, GeneralizedPareto,
+#     Gumbel, InverseGaussian, JohnsonSU, Kumaraswamy, Laplace, Levy, Lindley, Logistic,
+#     LogitNormal, LogNormal, LogUniform, NoncentralBeta, NoncentralChisq, NoncentralF,
+#     NoncentralT, Normal, NormalInverseGaussian, Pareto, PGeneralizedGaussian, Rayleigh,
+#     Rician, Semicircle, SkewedExponentialPower, SkewNormal, SymTriangularDist, TDist,
+#     TriangularDist, Triweight, Uniform, VonMises, Weibull, MvNormal, Distributions.Zeros,
+#     Distributions.ScalMat, Distributions.PDiagMat, PDMat, Cholesky, MvNormalCanon,
+#     MvLogitNormal, MvLogNormal, Product, MatrixBeta, Wishart, MatrixFDist, LKJ,
+#     Symmetric, MatrixNormal, InverseWishart, MatrixTDist,
+# ]
+#     @eval Taped._add_to_primal(p::$T, t) = Taped._containerlike_add_to_primal(p, t)
+#     @eval Taped._diff(p::$T, q::$T) = Taped._containerlike_diff(p, q)
+# end
 
 _sym(A) = A'A
 _pdmat(A) = PDMat(_sym(A) + 5I)

--- a/test/integration_testing/distributions.jl
+++ b/test/integration_testing/distributions.jl
@@ -1,20 +1,3 @@
-# Functionality to make testing straightforward.
-# for T in [
-#     Arcsine, Beta, BetaPrime, Biweight, Cauchy, Chi, Chisq, Chernoff, Cosine, Epanechnikov,
-#     Erlang, Exponential, FDist, Frechet, Gamma, GeneralizedExtremeValue, GeneralizedPareto,
-#     Gumbel, InverseGaussian, JohnsonSU, Kumaraswamy, Laplace, Levy, Lindley, Logistic,
-#     LogitNormal, LogNormal, LogUniform, NoncentralBeta, NoncentralChisq, NoncentralF,
-#     NoncentralT, Normal, NormalInverseGaussian, Pareto, PGeneralizedGaussian, Rayleigh,
-#     Rician, Semicircle, SkewedExponentialPower, SkewNormal, SymTriangularDist, TDist,
-#     TriangularDist, Triweight, Uniform, VonMises, Weibull, MvNormal, Distributions.Zeros,
-#     Distributions.ScalMat, Distributions.PDiagMat, PDMat, Cholesky, MvNormalCanon,
-#     MvLogitNormal, MvLogNormal, Product, MatrixBeta, Wishart, MatrixFDist, LKJ,
-#     Symmetric, MatrixNormal, InverseWishart, MatrixTDist,
-# ]
-#     @eval Taped._add_to_primal(p::$T, t) = Taped._containerlike_add_to_primal(p, t)
-#     @eval Taped._diff(p::$T, q::$T) = Taped._containerlike_diff(p, q)
-# end
-
 _sym(A) = A'A
 _pdmat(A) = PDMat(_sym(A) + 5I)
 


### PR DESCRIPTION
I think my previous stance was unjustified -- treating everything like a container by default should be safe, in the sense that it will not introduce silent failure.

It has the advantage of making it possible for testing to work completely automatically on many more types. Moreover, it prevents false-positives, where some bits of a type which probably ought not to be ignored are in fact ignored.

It has the disadvantage of exposing _all_ of the fields of types to testing, which is not what people want in all situations, and will present itself as false negative failures. For example, if a `Symmetric` matrix is returned, the correctness of AD w.r.t the entire parent matrix will be checked, not just w.r.t one of the triangles. This is often fine, but in other cases the value in the (strict) triangle not used to define the value of the `Symmetric` is non-deterministic. In such cases, it is the responsibility of the user to ensure that they modify their test to make it deterministic. We will probably need to implement helper functionality to make this straightforward for users.