### PR TITLE
Testing Improvements

### DIFF
--- a/test/rrules/iddict.jl
+++ b/test/rrules/iddict.jl
@@ -13,6 +13,7 @@
         (false, :none, setindex!, IdDict(true => 5.0, false => 4.0), 3.0, false),
         (false, :none, setindex!, IdDict(true => 5.0), 3.0, false),
         (false, :none, get, IdDict(true => 5.0, false => 4.0), false, 2.0),
+        (false, :none, get, IdDict(true => 5.0), false, 2.0),
         (false, :none, getindex, IdDict(true => 5.0, false => 4.0), true),
     ]
         test_rrule!!(Xoshiro(123456), f, x...; interface_only, perf_flag)

--- a/test/rrules/iddict.jl
+++ b/test/rrules/iddict.jl
@@ -6,7 +6,6 @@
         y = IdDict(true => 2.0, false => 1.0)
         rng = Xoshiro(123456)
         test_tangent(rng, p, z, x, y)
-        test_numerical_testing_interface(p, x)
     end
 
     @testset "$f, $(typeof(x))" for (interface_only, perf_flag, f, x...) in [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,8 +53,7 @@ using .TestUtils:
     AddressMap,
     populate_address_map!,
     populate_address_map,
-    test_tangent,
-    test_numerical_testing_interface
+    test_tangent
 
 using .TestResources:
     TypeStableMutableStruct,

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -104,7 +104,6 @@
     )
         rng = Xoshiro(123456)
         test_tangent(rng, p, z, x, y)
-        test_numerical_testing_interface(p, x)
     end
 
     tangent(nt::NamedTuple) = Tangent(map(PossiblyUninitTangent, nt))


### PR DESCRIPTION
This PR addresses a couple of things which yesterday's PR left open:
1. improves tangent testing infrastructure, in order to do a better job of detecting whether a tangent type has enough of the testing interface implemented on it to be able to use it in automated testing infrastructure, and
2. adds another test case for IdDict which I realised I had missed off.

The improved testing infrastructure actually found a subtle bug to do with `Core.SimpleVector`s, which is also fixed in this PR.