### PR TITLE
Improve setfield performance

### DIFF
--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -170,6 +170,10 @@ function lift_getfield_and_others(inst)
         field = inst.args[3]
         new_field = field isa Int ? Val(field) : Val(field.value)
         return Expr(:call, lgetfield, inst.args[2], new_field, Val(inst.args[4]))
+    elseif f === setfield! && length(inst.args) == 4 && inst.args[3] isa Union{QuoteNode, Int}
+        name = inst.args[3]
+        new_name = name isa Int ? Val(name) : Val(name.value)
+        return Expr(:call, lsetfield!, inst.args[2], new_name, inst.args[4])
     else
         return inst
     end

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -566,17 +566,17 @@ end
 
 # replacefield!
 
-function _setfield!(value::MutableTangent, name::Symbol, x)
+@inline function _setfield!(value::MutableTangent, name::Symbol, x)
     fields = value.fields
     value.fields = @set fields.$name = fieldtype(typeof(fields), name)(x)
     return x
 end
-function _setfield!(value::T, ind::Int, x) where {T<:MutableTangent}
+@inline function _setfield!(value::T, ind::Int, x) where {T<:MutableTangent}
     value.fields = _setfield!(value.fields, ind, x)
     return x
 end
 
-function _setfield!(value::T, ind::Int, x) where {T<:NamedTuple}
+@inline function _setfield!(value::T, ind::Int, x) where {T<:NamedTuple}
     return T(ntuple(n -> n == ind ? fieldtype(T, ind)(x) : value[n], length(value)))
 end
 

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -72,6 +72,18 @@ function rrule!!(::CoDual{typeof(lgetfield)}, x::CoDual, ::CoDual{Val{f}}, ::CoD
     return y, lgetfield_pb!!
 end
 
+"""
+    lsetfield!(value, name::Val, x, [order::Val])
+
+This function is to `setfield!` what `lgetfield` is to `getfield`. It will always hold that
+```julia
+setfield!(copy(x), :f, v) == lsetfield!(copy(x), Val(:f), v)
+setfield!(copy(x), 2, v) == lsetfield(copy(x), Val(2), v)
+```
+"""
+lsetfield!(value, ::Val{name}, x) where {name} = setfield!(value, name, x)
+
+
 function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
 
     # Data which needs to not be GC'd.

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -83,6 +83,26 @@ setfield!(copy(x), 2, v) == lsetfield(copy(x), Val(2), v)
 """
 lsetfield!(value, ::Val{name}, x) where {name} = setfield!(value, name, x)
 
+@is_primitive MinimalCtx Tuple{typeof(lsetfield!), Any, Any, Any}
+function rrule!!(
+    ::CoDual{typeof(lsetfield!)}, value::CoDual, ::CoDual{Val{name}}, x::CoDual
+) where {name}
+    save = isdefined(primal(value), name)
+    old_x = save ? getfield(primal(value), name) : nothing
+    old_dx = save ? val(getfield(tangent(value).fields, name)) : nothing
+    function setfield!_pullback(dy, df, dvalue, dname, dx)
+        new_dx = increment!!(dx, val(getfield(dvalue.fields, name)))
+        new_dx = increment!!(new_dx, dy)
+        old_x !== nothing && lsetfield!(primal(value), Val(name), old_x)
+        old_x !== nothing && _setfield!(tangent(value), name, old_dx)
+        return df, dvalue, dname, new_dx
+    end
+    y = CoDual(
+        lsetfield!(primal(value), Val(name), primal(x)),
+        _setfield!(tangent(value), name, tangent(x)),
+    )
+    return y, setfield!_pullback
+end
 
 function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
 
@@ -106,32 +126,52 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:misc})
         ),
 
         # Lack of activity-analysis rules:
-        (false, :stability, nothing, Base.elsize, randn(5, 4)),
-        (false, :stability, nothing, Base.elsize, view(randn(5, 4), 1:2, 1:2)),
-        (false, :stability, nothing, Core.Compiler.sizeof_nothrow, Float64),
-        (false, :stability, nothing, Base.datatype_haspadding, Float64),
+        (false, :stability_and_allocs, nothing, Base.elsize, randn(5, 4)),
+        (false, :stability_and_allocs, nothing, Base.elsize, view(randn(5, 4), 1:2, 1:2)),
+        (false, :stability_and_allocs, nothing, Core.Compiler.sizeof_nothrow, Float64),
+        (false, :stability_and_allocs, nothing, Base.datatype_haspadding, Float64),
 
         # Performance-rules that would ideally be completely removed.
-        (false, :stability, nothing, size, randn(5, 4)),
-        (false, :stability, nothing, LinearAlgebra.lapack_size, 'N', randn(5, 4)),
-        (false, :stability, nothing, Base.require_one_based_indexing, randn(2, 3), randn(2, 1)),
-        (false, :stability, nothing, in, 5.0, randn(4)),
-        (false, :stability, nothing, iszero, 5.0),
-        (false, :stability, nothing, isempty, randn(5)),
-        (false, :stability, nothing, isbitstype, Float64),
-        (false, :stability, nothing, sizeof, Float64),
-        (false, :stability, nothing, promote_type, Float64, Float64),
-        (false, :stability, nothing, LinearAlgebra.chkstride1, randn(3, 3)),
-        (false, :stability, nothing, LinearAlgebra.chkstride1, randn(3, 3), randn(2, 2)),
-        (false, :stability, nothing, Threads.nthreads),
+        (false, :stability_and_allocs, nothing, size, randn(5, 4)),
+        (false, :stability_and_allocs, nothing, LinearAlgebra.lapack_size, 'N', randn(5, 4)),
+        (false, :stability_and_allocs, nothing, Base.require_one_based_indexing, randn(2, 3), randn(2, 1)),
+        (false, :stability_and_allocs, nothing, in, 5.0, randn(4)),
+        (false, :stability_and_allocs, nothing, iszero, 5.0),
+        (false, :stability_and_allocs, nothing, isempty, randn(5)),
+        (false, :stability_and_allocs, nothing, isbitstype, Float64),
+        (false, :stability_and_allocs, nothing, sizeof, Float64),
+        (false, :stability_and_allocs, nothing, promote_type, Float64, Float64),
+        (false, :stability_and_allocs, nothing, LinearAlgebra.chkstride1, randn(3, 3)),
+        (false, :stability_and_allocs, nothing, LinearAlgebra.chkstride1, randn(3, 3), randn(2, 2)),
+        (false, :stability_and_allocs, nothing, Threads.nthreads),
 
-        # Literal replacements for getfield and others.
-        (false, :stability, nothing, lgetfield, (5.0, 4), Val(1)),
-        (false, :stability, nothing, lgetfield, (5.0, 4), Val(2)),
-        (false, :stability, nothing, lgetfield, (a=5.0, b=4), Val(1)),
-        (false, :stability, nothing, lgetfield, (a=5.0, b=4), Val(2)),
-        (false, :stability, nothing, lgetfield, (a=5.0, b=4), Val(:a)),
-        (false, :stability, nothing, lgetfield, (a=5.0, b=4), Val(:b)),
+        # Literal replacements for getfield.
+        (false, :stability_and_allocs, nothing, lgetfield, (5.0, 4), Val(1)),
+        (false, :stability_and_allocs, nothing, lgetfield, (5.0, 4), Val(2)),
+        (false, :stability_and_allocs, nothing, lgetfield, (a=5.0, b=4), Val(1)),
+        (false, :stability_and_allocs, nothing, lgetfield, (a=5.0, b=4), Val(2)),
+        (false, :stability_and_allocs, nothing, lgetfield, (a=5.0, b=4), Val(:a)),
+        (false, :stability_and_allocs, nothing, lgetfield, (a=5.0, b=4), Val(:b)),
+
+        # Literal replacement for setfield!.
+        (
+            false,
+            :stability_and_allocs,
+            nothing,
+            lsetfield!,
+            TestResources.MutableFoo(5.0, [1.0, 2.0]),
+            Val(:a),
+            4.0,
+        ),
+        (
+            false,
+            :stability,
+            nothing,
+            lsetfield!,
+            TestResources.FullyInitMutableStruct(5.0, [1.0, 2.0]),
+            Val(:y),
+            [1.0, 3.0, 4.0],
+        ),
     ]
     return test_cases, memory
 end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -8,9 +8,8 @@ Semantically equivalent to a usual stack, but never de-allocates memory once all
 mutable struct Stack{T}
     memory::Vector{T}
     position::Int
+    Stack{T}() where {T} = new{T}(Vector{T}(undef, 0), 0)
 end
-
-Stack{T}() where {T} = Stack{T}(Vector{T}(undef, 0), 0)
 
 function Base.push!(x::Stack{T}, val::T) where {T}
     position = x.position + 1

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -248,8 +248,8 @@ function __forwards_and_backwards(rule, x_x̄::Vararg{Any, N}) where {N}
 end
 
 function test_rrule_performance(
-    performance_checks_flag::Symbol, rule, f_f̄, x_x̄::Vararg{Any, N}
-) where {N}
+    performance_checks_flag::Symbol, rule::R, f_f̄::F, x_x̄::Vararg{Any, N}
+) where {R, F, N}
 
     # Verify that a valid performance flag has been passed.
     valid_flags = (:none, :stability, :allocs, :stability_and_allocs)
@@ -633,6 +633,15 @@ function Base.:(==)(a::TypeStableStruct, b::TypeStableStruct)
     return equal_field(a, b, :a) && equal_field(a, b, :b)
 end
 
+mutable struct FullyInitMutableStruct
+    x::Float64
+    y::Vector{Float64}
+end
+
+function Base.:(==)(a::FullyInitMutableStruct, b::FullyInitMutableStruct)
+    return equal_field(a, b, :x) && equal_field(a, b, :y)
+end
+
 
 
 #
@@ -882,8 +891,13 @@ inferred_const_tester(x::Int) = x == 5 ? x : 5x
 getfield_tester(x::Tuple) = x[1]
 getfield_tester_2(x::Tuple) = getfield(x, 1)
 
-function setfield_tester!(x::TypeStableMutableStruct, new_field)
-    x.b = new_field
+function setfield_tester_left!(x::FullyInitMutableStruct, new_field)
+    x.x = new_field
+    return new_field
+end
+
+function setfield_tester_right!(x::FullyInitMutableStruct, new_field)
+    x.y = new_field
     return new_field
 end
 
@@ -1091,19 +1105,19 @@ function generate_test_functions()
         (false, :allocs, (lb=1, ub=1_000), getfield_tester_2, (5.0, 5)),
         (
             false,
-            :none,
+            :allocs,
             (lb=1, ub=1_000),
-            setfield_tester!,
-            TypeStableMutableStruct{Symbol}(5.0, :hi),
-            :boo,
+            setfield_tester_left!,
+            FullyInitMutableStruct(5.0, randn(3)),
+            4.0,
         ),
         (
             false,
             :none,
             (lb=1, ub=1_000),
-            setfield_tester!,
-            TypeStableMutableStruct{Float64}(5.0,  1.0),
-            2.0,
+            setfield_tester_right!,
+            FullyInitMutableStruct(5.0, randn(3)),
+            randn(5),
         ),
         (
             false, :none, (lb=100, ub=1_000_000),

--- a/test/interpreter/ir_normalisation.jl
+++ b/test/interpreter/ir_normalisation.jl
@@ -70,6 +70,18 @@
             Expr(:call, lgetfield, SSAValue(1), Val(:x)),
         ),
         (
+            Expr(:call, GlobalRef(Core, :setfield!), SSAValue(1), 2, SSAValue(3)),
+            Expr(:call, lsetfield!, SSAValue(1), Val(2), SSAValue(3)),
+        ),
+        (
+            Expr(:call, setfield!, SSAValue(1), 2, SSAValue(3)),
+            Expr(:call, lsetfield!, SSAValue(1), Val(2), SSAValue(3)),
+        ),
+        (
+            Expr(:call, setfield!, SSAValue(1), QuoteNode(:a), SSAValue(3)),
+            Expr(:call, lsetfield!, SSAValue(1), Val(:a), SSAValue(3)),
+        ),
+        (
             Expr(:call, sin, SSAValue(1)),
             Expr(:call, sin, SSAValue(1)),
         ),

--- a/test/rrules/misc.jl
+++ b/test/rrules/misc.jl
@@ -8,5 +8,24 @@
         @test Taped.wrap_ptr_as_view(p, 4, 2, 3) == x[1:2, 1:3]
     end
 
+    @testset "lgetfield" begin
+        x = (5.0, 4)
+        @test lgetfield(x, Val(1)) == getfield(x, 1)
+        @test lgetfield(x, Val(2)) == getfield(x, 2)
+
+        y = (a=5.0, b=4)
+        @test lgetfield(y, Val(:a)) == getfield(y, :a)
+        @test lgetfield(y, Val(:b)) == getfield(y, :b)
+    end
+    @testset "lsetfield!" begin
+        x = TestResources.MutableFoo(5.0, randn(5))
+        @test Taped.lsetfield!(x, Val(:a), 4.0) == 4.0
+        @test x.a == 4.0
+
+        new_b = zeros(10)
+        @test Taped.lsetfield!(x, Val(:b), new_b) === new_b
+        @test x.b === new_b
+    end
+
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:misc))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ using Taped:
     DefaultCtx,
     rrule!!,
     lgetfield,
+    lsetfield!,
     might_be_active,
     build_tangent,
     SlotRef,


### PR DESCRIPTION
We weren't lifting `setfield!`, meaning that constant values for `name` were not getting propagated, and type-stability was being lost. This PR sorts that out.