### PR TITLE
Tidy up and improve tangent_type performance

### DIFF
--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -238,7 +238,7 @@ function build_coinsts(ir_inst::Expr, in_f, _rrule!!, n::Int, b::Int, is_blk_end
         old_vals = Stack{eltype(val_slot)}()
 
         return build_coinsts(
-            Val(:call), val_slot, arg_slots, evaluator, __rrule!!, old_vals, pb_stack, next_blk,
+            Val(:call), val_slot, arg_slots, evaluator, __rrule!!, old_vals, pb_stack, next_blk
         )
     elseif ir_inst.head in [
         :code_coverage_effect, :gc_preserve_begin, :gc_preserve_end, :loopinfo,

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -238,7 +238,7 @@ function build_coinsts(ir_inst::Expr, in_f, _rrule!!, n::Int, b::Int, is_blk_end
         old_vals = Stack{eltype(val_slot)}()
 
         return build_coinsts(
-            Val(:call), val_slot, arg_slots, evaluator, __rrule!!, old_vals, pb_stack, next_blk, ir_inst,
+            Val(:call), val_slot, arg_slots, evaluator, __rrule!!, old_vals, pb_stack, next_blk,
         )
     elseif ir_inst.head in [
         :code_coverage_effect, :gc_preserve_begin, :gc_preserve_end, :loopinfo,
@@ -283,7 +283,6 @@ function build_coinsts(
     old_vals::Stack,
     pb_stack::Stack,
     next_blk::Int,
-    ir_inst,
 ) where {Teval, Trrule!!}
 
     function fwds_pass()

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -148,7 +148,7 @@ end
 
 tangent_type(::Type{NamedTuple{N, T}}) where {N, T<:Tuple} = NamedTuple{N, tangent_type(T)}
 
-function tangent_type(::Type{P}) where {P}
+@generated function tangent_type(::Type{P}) where {P}
 
     # This method can only handle struct types. Tell user to implement tangent type
     # directly for primitive types.


### PR DESCRIPTION
`tangent_type` was sometimes not properly constant folding. It only depended on the type of its argument anyway, so it is fine to just make it a generated function.