### PR TITLE
Simplify PhiNodes

### DIFF
--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -556,7 +556,7 @@ function (if_pb!!::InterpretedFunctionPb)(dout, ::NoTangent, dargs::Vararg{Any, 
     replace_tangent!(if_pb!!.return_slot, dout)
     load_tangents!(if_pb!!.arg_info, dargs)
 
-    # Run the instructions in reverse. Present assumes linear instruction ordering.
+    # Run the instructions in reverse.
     n_stack = if_pb!!.n_stack
     bwds_instructions = if_pb!!.bwds_instructions
     while length(n_stack) > if_pb!!.j

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -34,3 +34,5 @@ end
 Base.isempty(x::Stack) = x.position == 0
 
 Base.length(x::Stack) = x.position
+
+Base.peek(x::Stack) = x.memory[x.position]

--- a/test/interpreter/reverse_mode_ad.jl
+++ b/test/interpreter/reverse_mode_ad.jl
@@ -113,7 +113,7 @@
             next_blk = 0
             prev_blk = 1
             fwds_inst, bwds_inst = build_coinsts(
-                Vector{PhiNode}, nodes, next_blk, Taped.make_stacks(nodes)...
+                Vector{PhiNode}, nodes, next_blk, Taped.Stack{Int}()
             )
 
             # Test forwards instructions.

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -3,6 +3,7 @@
     push!(s, 5.0)
     @test s.position == 1
     @test s.memory[1] == 5.0
+    @test peek(s) == 5.0
     @test length(s) == 1
     @test !isempty(s)
     @test pop!(s) == 5.0


### PR DESCRIPTION
Turns out we don't need to maintain a stack for each PhiNode. This is important from a code-complexity perspective, and for the performance of hot loops.