### PR TITLE
Static is_primitive

### DIFF
--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -76,7 +76,7 @@ function CC.inlining_policy(
 
     # Do not inline away primitives.
     argtype_tuple = Tuple{map(_type, argtypes)...}
-    is_primitive(interp.ctx, argtype_tuple) && return nothing
+    is_primitive(C, argtype_tuple) && return nothing
 
     # If not a primitive, AD doesn't care about it. Use the usual inlining strategy.
     return @invoke CC.inlining_policy(

--- a/src/interpreter/contexts.jl
+++ b/src/interpreter/contexts.jl
@@ -7,8 +7,6 @@ performance only -- instead, make these primitives in the DefaultCtx.
 """
 struct MinimalCtx end
 
-is_primitive(::MinimalCtx, ::Any) = false
-
 """
     struct DefaultCtx end
 
@@ -18,7 +16,24 @@ performance, it should be a primitive in the DefaultCtx, but not the MinimalCtx.
 """
 struct DefaultCtx end
 
-is_primitive(::DefaultCtx, sig) = is_primitive(MinimalCtx(), sig)
+"""
+    is_primitive(::Type{Ctx}, sig) where {Ctx}
+
+Returns a `Bool` specifying whether the methods specified by `sig` are considered primitives
+in the context of contexts of type `Ctx`.
+
+```julia
+is_primitive(DefaultCtx, Tuple{typeof(sin), Float64})
+```
+will return if calling `sin(5.0)` should be treated as primitive when the context is a
+`DefaultCtx`.
+
+Observe that this information means that whether or not something is a primitive in a
+particular context depends only on static information, not any run-time information that
+might live in a particular instance of `Ctx`.
+"""
+is_primitive(::Type{MinimalCtx}, ::Any) = false
+is_primitive(::Type{DefaultCtx}, sig) = is_primitive(MinimalCtx(), sig)
 
 """
     @is_primitive context_type signature
@@ -30,11 +45,11 @@ Creates a method of `is_primitive` which always returns `true` for the context_t
 ```
 is equivalent to
 ```julia
-is_primitive(::MinimalCtx, ::Type{<:Tuple{typeof(foo), Float64}}) = true
+is_primitive(::Type{MinimalCtx}, ::Type{<:Tuple{typeof(foo), Float64}}) = true
 ```
 
 You should implemented more complicated method of `is_primitive` in the usual way.
 """
 macro is_primitive(Tctx, sig)
-    return esc(:(Taped.is_primitive(::$Tctx, ::Type{<:$sig}) = true))
+    return esc(:(Taped.is_primitive(::Type{$Tctx}, ::Type{<:$sig}) = true))
 end

--- a/src/interpreter/contexts.jl
+++ b/src/interpreter/contexts.jl
@@ -33,7 +33,7 @@ particular context depends only on static information, not any run-time informat
 might live in a particular instance of `Ctx`.
 """
 is_primitive(::Type{MinimalCtx}, ::Any) = false
-is_primitive(::Type{DefaultCtx}, sig) = is_primitive(MinimalCtx(), sig)
+is_primitive(::Type{DefaultCtx}, sig) = is_primitive(MinimalCtx, sig)
 
 """
     @is_primitive context_type signature

--- a/src/interpreter/interpreted_function.jl
+++ b/src/interpreter/interpreted_function.jl
@@ -236,7 +236,7 @@ function build_inst(x::Expr, @nospecialize(in_f), n::Int, b::Int, is_blk_end::Bo
 end
 
 function get_evaluator(ctx::T, sig, interp, is_invoke::Bool) where {T}
-    is_primitive(ctx, sig) && return _eval
+    is_primitive(T, sig) && return _eval
     is_invoke && return InterpretedFunction(ctx, sig, interp)
     return DelayedInterpretedFunction(ctx, Dict(), interp)
 end
@@ -597,12 +597,12 @@ struct DelayedInterpretedFunction{C, Tlocal_cache, T<:TapedInterpreter}
     interp::T
 end
 
-function (din_f::DelayedInterpretedFunction)(fargs::Vararg{Any, N}) where {N}
+function (din_f::DelayedInterpretedFunction{C})(fargs::Vararg{Any, N}) where {C, N}
     k = map(Core.Typeof, fargs)
     _evaluator = get(din_f.local_cache, k, nothing)
     if _evaluator === nothing
         sig = Tuple{map(Core.Typeof, fargs)...}
-        _evaluator = if is_primitive(din_f.ctx, sig)
+        _evaluator = if is_primitive(C, sig)
             _eval
         else
             InterpretedFunction(din_f.ctx, sig, din_f.interp)

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -344,7 +344,7 @@ end
 function rrule!!(_f::CoDual{<:DelayedInterpretedFunction{C, F}}, args::CoDual...) where {C, F}
     f = primal(_f)
     s = Tuple{map(Core.Typeof ∘ primal, args)...}
-    if is_primitive(f.ctx, s)
+    if is_primitive(C, s)
         return rrule!!(zero_codual(f.f), args...)
     else
         in_f = InterpretedFunction(f.ctx, s, f.interp)

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -118,7 +118,7 @@ special handling of `cglobal` is used.
 __cglobal(::Val{s}, x::Vararg{Any, N}) where {s, N} = cglobal(s, x...)
 
 translate(::Val{Intrinsics.cglobal}) = __cglobal
-Taped.is_primitive(::MinimalCtx, ::Type{<:Tuple{typeof(__cglobal), Vararg}}) = true
+Taped.is_primitive(::Type{MinimalCtx}, ::Type{<:Tuple{typeof(__cglobal), Vararg}}) = true
 function rrule!!(::CoDual{typeof(__cglobal)}, args...)
     return Taped.uninit_codual(__cglobal(map(primal, args)...)), NoPullback()
 end

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -28,7 +28,7 @@ end
 macro intrinsic(name)
     expr = quote
         $name(x...) = Intrinsics.$name(x...)
-        (is_primitive)(::MinimalCtx, ::Type{<:Tuple{typeof($name), Vararg}}) = true
+        (is_primitive)(::Type{MinimalCtx}, ::Type{<:Tuple{typeof($name), Vararg}}) = true
         translate(::Val{Intrinsics.$name}) = $name
     end
     return esc(expr)
@@ -37,7 +37,7 @@ end
 macro inactive_intrinsic(name)
     expr = quote
         $name(x...) = Intrinsics.$name(x...)
-        (is_primitive)(::MinimalCtx, ::Type{<:Tuple{typeof($name), Vararg}}) = true
+        (is_primitive)(::Type{MinimalCtx}, ::Type{<:Tuple{typeof($name), Vararg}}) = true
         translate(::Val{Intrinsics.$name}) = $name
         function rrule!!(::CoDual{typeof($name)}, args...)
             y = $name(map(primal, args)...)

--- a/test/interpreter/abstract_interpretation.jl
+++ b/test/interpreter/abstract_interpretation.jl
@@ -1,8 +1,8 @@
 a_primitive(x) = sin(x)
 non_primitive(x) = sin(x)
 
-Taped.is_primitive(::DefaultCtx, ::Type{<:Tuple{typeof(a_primitive), Any}}) = true
-Taped.is_primitive(::DefaultCtx, ::Type{<:Tuple{typeof(non_primitive), Any}}) = false
+Taped.is_primitive(::Type{DefaultCtx}, ::Type{<:Tuple{typeof(a_primitive), Any}}) = true
+Taped.is_primitive(::Type{DefaultCtx}, ::Type{<:Tuple{typeof(non_primitive), Any}}) = false
 
 contains_primitive(x) = @inline a_primitive(x)
 contains_non_primitive(x) = @inline non_primitive(x)


### PR DESCRIPTION
Modifies `is_primitive` to always accept the type of a context, rather than an instance, when deciding whether something is primitive or not. This doesn't affect any aspects of how things are currently implemented because only static properties are used anywhere at the minute.

This is partly paying down some tech debt (I've felt that this is probably the right thing to do for a while), but it's also important for the sake of performance when handling dynamic dispatch (there are some situations in which it's useful to know whether or not something is a primitive in the body of a generated function, which means that is_primitive can only depend on the type of the context).

edit: increase in line count is due to a new docstring for `is_primitive`. Everything else is a 1-for-1 replacement.