### PR TITLE
Stacks Not Slots

### DIFF
--- a/src/interpreter/interpreted_function.jl
+++ b/src/interpreter/interpreted_function.jl
@@ -2,6 +2,8 @@
 
 abstract type AbstractSlot{T} end
 
+Base.eltype(::AbstractSlot{T}) where {T} = T
+
 """
     SlotRef{T}()
 
@@ -26,7 +28,6 @@ end
 Base.getindex(x::SlotRef) = getfield(x, :x)
 Base.setindex!(x::SlotRef, val) = setfield!(x, :x, val)
 Base.isassigned(x::SlotRef) = isdefined(x, :x)
-Base.eltype(::SlotRef{T}) where {T} = T
 Base.copy(x::SlotRef{T}) where {T} = isassigned(x) ? SlotRef{T}(x[]) : SlotRef{T}()
 
 """
@@ -44,7 +45,6 @@ end
 Base.getindex(x::ConstSlot) = getfield(x, :x)
 Base.setindex!(::ConstSlot, val) = nothing
 Base.isassigned(::ConstSlot) = true
-Base.eltype(::ConstSlot{T}) where {T} = T
 Base.copy(x::ConstSlot{T}) where {T} = ConstSlot{T}(x[])
 
 """
@@ -68,7 +68,6 @@ TypedGlobalRef(mod::Module, name::Symbol) = TypedGlobalRef(GlobalRef(mod, name))
 Base.getindex(x::TypedGlobalRef{T}) where {T} = getglobal(x.mod, x.name)::T
 Base.setindex!(x::TypedGlobalRef, val) = setglobal!(x.mod, x.name, val)
 Base.isassigned(::TypedGlobalRef) = true
-Base.eltype(::TypedGlobalRef{T}) where {T} = T
 
 #=
 Returns either a `ConstSlot` or a `TypedGlobalRef`, both of which are `AbstractSlot`s.

--- a/src/interpreter/interpreted_function.jl
+++ b/src/interpreter/interpreted_function.jl
@@ -1,9 +1,5 @@
 # Special types to represent data in an IRCode and a InterpretedFunction.
 
-abstract type AbstractSlot{T} end
-
-Base.eltype(::AbstractSlot{T}) where {T} = T
-
 """
     SlotRef{T}()
 
@@ -120,8 +116,8 @@ end
 
 ## PhiNode
 
-struct TypedPhiNode{Tr<:AbstractSlot, Te<:Tuple, Tv<:Tuple}
-    tmp_slot::Tr
+struct TypedPhiNode{Tr<:AbstractSlot, Tt<:AbstractSlot, Te<:Tuple, Tv<:Tuple}
+    tmp_slot::Tt
     ret_slot::Tr
     edges::Te
     values::Tv
@@ -152,7 +148,7 @@ function build_typed_phi_nodes(ir_insts::Vector{PhiNode}, in_f, n_first::Int)
         end
         T = eltype(ret_slot)
         values_vec = map(n -> _init[n] isa UndefRef ? SlotRef{T}() : _init[n], eachindex(_init))
-        return TypedPhiNode(copy(ret_slot), ret_slot, edges, (values_vec..., ))
+        return TypedPhiNode(SlotRef{T}(), ret_slot, edges, (values_vec..., ))
     end
 end
 

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -1,3 +1,7 @@
+abstract type AbstractSlot{T} end
+
+Base.eltype(::AbstractSlot{T}) where {T} = T
+
 """
     Stack{T}()
 
@@ -5,10 +9,16 @@ A stack specialised for reverse-mode AD.
 
 Semantically equivalent to a usual stack, but never de-allocates memory once allocated.
 """
-mutable struct Stack{T}
+mutable struct Stack{T} <: AbstractSlot{T}
     memory::Vector{T}
     position::Int
     Stack{T}() where {T} = new{T}(Vector{T}(undef, 0), 0)
+end
+
+function Stack(x::T) where {T}
+    stack = Stack{T}()
+    push!(stack, x)
+    return stack
 end
 
 function Base.push!(x::Stack{T}, val::T) where {T}
@@ -51,3 +61,5 @@ function Base.setindex!(x::Stack, v)
     x.memory[x.position] = v
     return v
 end
+
+Base.isassigned(x::Stack) = length(x) > 0

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -34,3 +34,20 @@ end
 Base.isempty(x::Stack) = x.position == 0
 
 Base.length(x::Stack) = x.position
+
+"""
+    Base.getindex(x::Stack)
+
+Return the value at the top of `x` without popping it.
+"""
+Base.getindex(x::Stack) = x.memory[x.position]
+
+"""
+    Base.setindex!(x::Stack, v)
+
+Set the value of the element at the top of the `x` to `v`.
+"""
+function Base.setindex!(x::Stack, v)
+    x.memory[x.position] = v
+    return v
+end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -5,7 +5,10 @@
     @test s.memory[1] == 5.0
     @test length(s) == 1
     @test !isempty(s)
-    @test pop!(s) == 5.0
+
+    s[] = 6.0
+    @test s[] == 6.0
+    @test pop!(s) == 6.0
     @test s.position == 0
     @test length(s) == 0
     @test isempty(s)


### PR DESCRIPTION
Replace all slots with stacks in an AD context. This is the first step in the road to having only tangents in stacks, and optimising away loads of stuff once that is the case.