### PR TITLE
Simplify PhiNodes

### DIFF
--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -98,17 +98,12 @@ end
 function build_coinsts(
     ::Type{Vector{PhiNode}}, nodes::NTuple{N, TypedPhiNode}, next_blk::Int,
 ) where {N}
-
     # Check that we're operating on CoDuals.
     @assert all(x -> x.ret_slot isa CoDualSlot, nodes)
     @assert all(x -> all(y -> isa(y, CoDualSlot), x.values), nodes)
 
     # Construct instructions.
-    fwds_inst = @opaque function (p::Int)
-        map(Base.Fix2(store_tmp_value!, p), nodes) # transfer new value into tmp slots
-        map(Base.Fix2(transfer_tmp_value!, p), nodes) # transfer new value from tmp slots into ret slots
-        return next_blk
-    end
+    fwds_inst = build_inst(Vector{PhiNode}, nodes, next_blk)
     bwds_inst = @opaque (j::Int) -> j
     return fwds_inst::FwdsInst, bwds_inst::BwdsInst
 end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -1,7 +1,3 @@
-abstract type AbstractSlot{T} end
-
-Base.eltype(::AbstractSlot{T}) where {T} = T
-
 """
     Stack{T}()
 
@@ -9,17 +5,19 @@ A stack specialised for reverse-mode AD.
 
 Semantically equivalent to a usual stack, but never de-allocates memory once allocated.
 """
-mutable struct Stack{T} <: AbstractSlot{T}
+mutable struct Stack{T}
     memory::Vector{T}
     position::Int
     Stack{T}() where {T} = new{T}(Vector{T}(undef, 0), 0)
 end
 
-function Stack(x::T) where {T}
+function Stack{T}(x) where {T}
     stack = Stack{T}()
     push!(stack, x)
     return stack
 end
+
+Stack(x::T) where {T} = Stack{T}(x)
 
 function Base.push!(x::Stack{T}, val::T) where {T}
     position = x.position + 1
@@ -62,4 +60,6 @@ function Base.setindex!(x::Stack, v)
     return v
 end
 
-Base.isassigned(x::Stack) = length(x) > 0
+Base.eltype(::Stack{T}) where {T} = T
+
+top_ref(x::Stack) = Ref(x.memory, x.position)

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -187,7 +187,7 @@ tangent_type(::Type{String}) = NoTangent
 
 tangent_type(::Type{<:Array{P, N}}) where {P, N} = Array{tangent_type(P), N}
 
-tangent_type(::Type{<:Array{P, N} where {P}}) where {N} = Array{Any, N}
+tangent_type(::Type{<:Array{P, N} where {P}}) where {N} = Array
 
 tangent_type(::Type{<:MersenneTwister}) = NoTangent
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1305,10 +1305,12 @@ end
 function test_multiple_phinode_block(x::Float64)
     a = 1.0
     b = x
-    for i in 1:2
+    i = 1
+    while i < 3
         temp = a
         a = b
         b = 2temp
+        i += 1
     end
     return (a, b)
 end
@@ -1401,6 +1403,7 @@ function generate_test_functions()
         (false, :allocs, nothing, phi_const_bool_tester, -5.0),
         (false, :allocs, nothing, phi_node_with_undefined_value, true, 4.0),
         (false, :allocs, nothing, phi_node_with_undefined_value, false, 4.0),
+        (false, :allocs, nothing, test_multiple_phinode_block, 3.0),
         (
             false,
             :none,
@@ -1488,7 +1491,6 @@ function generate_test_functions()
         (false, :allocs, nothing, test_mutation!, [1.0, 2.0]),
         (false, :allocs, nothing, test_while_loop, 2.0),
         (false, :allocs, nothing, test_for_loop, 3.0),
-        (false, :allocs, nothing, test_multiple_phinode_block, 3.0),
         (false, :none, nothing, test_mutable_struct_basic, 5.0),
         (false, :none, nothing, test_mutable_struct_basic_sin, 5.0),
         (false, :none, nothing, test_mutable_struct_setfield, 4.0),

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1500,7 +1500,7 @@ function generate_test_functions()
         (
             false,
             :allocs,
-            (lb=100, ub=1_000),
+            (lb=100, ub=2_000),
             test_naive_mat_mul!, randn(100, 50), randn(100, 30), randn(30, 50),
         ),
         (

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1506,7 +1506,7 @@ function generate_test_functions()
         (
             false,
             :allocs,
-            (lb=100, ub=1_000),
+            (lb=100, ub=2_000),
             (A, C) -> test_naive_mat_mul!(C, A, A), randn(100, 100), randn(100, 100),
         ),
         (false, :allocs, (lb=10, ub=1_000), sum, randn(30)),

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -38,7 +38,9 @@ using Taped:
     build_coinsts,
     Stack,
     _typeof,
-    FwdStack
+    get_codual,
+    get_tangent_stack,
+    top_ref
 
 using .TestUtils:
     test_rrule!!,


### PR DESCRIPTION
This PR changes the way that AD is implemented to ensure that PhiNodes are straightforward to handle. The rationale for this is that I keep discovering more and more edge cases involving undefined values in PhiNodes that previous iterations of AD were sensitive to (these are not bugs -- they are just part of how phi nodes work in Julia, and the documentation could do with some improving).

The strategy adopted here is to choose a way of doing AD which simply leaves phi nodes alone -- that is, the forwards-pass of AD for phi nodes is simply to run the exact same phi nodes with different data.

Various other bits of AD have to change to accomodate this, but the dramatic reduction in complexity associated to phi nodes means that, overall, the complexity is lower in the sense that there is no need (really) to understand some complicated transformation of phi nodes in order to understand AD.

This PR has hit performance a little, because `:call` / `:invoke` instructions now have to keep track of various stacks. My plan is therefore to optimise this over the next couple of PRs, so specialise storage so that e.g. `NoTangent`s don't need stacks at all.