### PR TITLE
Optimise for NoTangent

### DIFF
--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -189,11 +189,11 @@ function build_pb_stack(__rrule!!, evaluator, arg_slots)
     end
     T_pb!! = only(possible_output_types)
     if T_pb!! <: Tuple && T_pb!! !== Union{}
-        pb_stack = Stack{T_pb!!.parameters[2]}()
+        F = T_pb!!.parameters[2]
+        return Base.issingletontype(F) ? SingletonStack{F}() : Stack{F}()
     else
-        pb_stack = Stack{Any}()
+        return Stack{Any}()
     end
-    return pb_stack
 end
 
 function build_coinsts(ir_inst::Expr, P, in_f, _rrule!!, n::Int, b::Int, is_blk_end::Bool)
@@ -249,7 +249,7 @@ function build_coinsts(
     arg_slots::NTuple{N, RuleSlot} where {N},
     evaluator::Teval,
     __rrule!!::Trrule!!,
-    pb_stack::Stack,
+    pb_stack,
     next_blk::Int,
 ) where {P, Teval, Trrule!!}
 

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -338,10 +338,6 @@ function make_codual_arginfo(ai::ArgInfo{T, is_vararg}) where {T, is_vararg}
     return ArgInfo{_typeof(arg_slots), is_vararg}(arg_slots)
 end
 
-# function make_arg_tangent_stacks(ai::ArgInfo)
-#     return map(a -> __tangent_stack_type(_typeof(a))(), ai.arg_slots)
-# end
-
 function make_arg_tangent_stacks(argtypes::Vector{Any})
     arg_types = (map(_get_type, argtypes)...,)
     return map(a -> tangent_stack_type(a)(), arg_types)

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -11,9 +11,6 @@ const BwdsInst = Core.OpaqueClosure{Tuple{Int}, Int}
 
 const RuleSlot{V} = Union{SlotRef{V}, ConstSlot{V}} where {V<:Tuple{CoDual, Ref}}
 
-__codual_type(::Type{<:Tuple{C, <:Ref}}) where {C<:CoDual} = @isdefined(C) ? C : CoDual
-__codual_type(::Type{<:RuleSlot{V}}) where {V} = @isdefined(V) ? __codual_type(V) : CoDual
-
 primal_type(::AbstractSlot{<:Tuple{<:CoDual{P}, <:Any}}) where {P} = @isdefined(P) ? P : Any
 primal_type(::AbstractSlot{<:Tuple{<:CoDual, <:Any}}) = Any
 

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -88,7 +88,7 @@ function build_coinsts(
 end
 
 ## PiNode
-function build_coinsts(x::PiNode, in_f, _rrule!!, n::Int, b::Int, is_blk_end::Bool)
+function build_coinsts(x::PiNode, _, _rrule!!, n::Int, b::Int, is_blk_end::Bool)
     val = _get_slot(x.val, _rrule!!)
     ret = _rrule!!.slots[n]
     return build_coinsts(PiNode, val, ret, _standard_next_block(is_blk_end, b))

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -29,6 +29,9 @@ end
 
 make_tangent_stack(::Type{P}) where {P} = tangent_stack_type(P)()
 
+make_tangent_ref_stack(::Type{P}) where {P} = Stack{P}()
+make_tangent_ref_stack(::Type{NoTangentRef}) = NoTangentRefStack()
+
 get_codual(x::RuleSlot) = x[][1]
 get_tangent_stack(x::RuleSlot) = x[][2]
 
@@ -105,7 +108,7 @@ function build_coinsts(
 ) where {R}
 
     my_tangent_stack = make_tangent_stack(primal_type(ret))
-    tangent_stack_stack = Stack{tangent_ref_type_ub(primal_type(val))}()
+    tangent_stack_stack = make_tangent_ref_stack(tangent_ref_type_ub(primal_type(val)))
 
     make_fwds(v) = R(primal(v), tangent(v))
     fwds_inst = @opaque function (p::Int)
@@ -251,7 +254,7 @@ function build_coinsts(
     my_tangent_stack = make_tangent_stack(primal_type(out))
 
     tangent_stack_stacks = map(arg_slots) do arg_slot
-        Stack{tangent_ref_type_ub(primal_type(arg_slot))}()
+        make_tangent_ref_stack(tangent_ref_type_ub(primal_type(arg_slot)))
     end
 
     function fwds_pass()

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -28,8 +28,7 @@ end
 get_codual(x::RuleSlot) = x[][1]
 get_tangent_stack(x::RuleSlot) = x[][2]
 
-increment_ref!(x::Base.RefArray, t) = setindex!(x, increment!!(x[], t))
-increment_ref!(x::Base.RefValue, t) = setindex!(x, increment!!(x[], t))
+increment_ref!(x::Ref, t) = setindex!(x, increment!!(x[], t))
 
 ## ReturnNode
 function build_coinsts(node::ReturnNode, _, _rrule!!, ::Int, ::Int, ::Bool)

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -440,7 +440,6 @@ function build_rrule!!(in_f::InterpretedFunction{sig}) where {sig}
     # Construct rrule!! for in_f.
     Tret = eltype(return_slot)
     Tret_tangent = eltype(return_tangent_slot)
-
     __rrule!! =  InterpretedFunctionRRule{
         sig, Tret, Tret_tangent, _typeof(arg_info), _typeof(arg_tangent_stacks)
     }(

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -339,8 +339,7 @@ function make_codual_arginfo(ai::ArgInfo{T, is_vararg}) where {T, is_vararg}
 end
 
 function make_arg_tangent_stacks(argtypes::Vector{Any})
-    arg_types = (map(_get_type, argtypes)...,)
-    return map(a -> tangent_stack_type(a)(), arg_types)
+    return map(a -> tangent_stack_type(a)(), (map(_get_type, argtypes)...,))
 end
 
 function load_rrule_args!(

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -81,5 +81,3 @@ function tangent_ref_type_ub(::Type{P}) where {P}
 end
 
 tangent_ref_type_ub(::Type{Type{P}}) where {P} = __array_ref_type(NoTangent)
-
-tangent_ref_type(::Type{P}) where {P} = __array_ref_type(tangent_type(P))

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -65,7 +65,7 @@ Base.eltype(::Stack{T}) where {T} = T
 top_ref(x::Stack) = Ref(x.memory, x.position)
 
 function tangent_stack_type_ub(::Type{P}) where {P}
-    P === DataType && return Stack{NoTangent}
+    P === DataType && return Stack
     return isconcretetype(P) ? Stack{P} : Stack
 end
 
@@ -76,7 +76,7 @@ tangent_stack_type(::Type{P}) where {P} = Stack{tangent_type(P)}
 __array_ref_type(::Type{P}) where {P} = Base.RefArray{P, Vector{P}, Nothing}
 
 function tangent_ref_type_ub(::Type{P}) where {P}
-    P === DataType && return __array_ref_type(NoTangent)
+    P === DataType && return Base.RefArray
     return isconcretetype(P) ? __array_ref_type(tangent_type(P)) : Base.RefArray
 end
 

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -72,3 +72,14 @@ end
 tangent_stack_type_ub(::Type{Type{P}}) where {P} = Stack{NoTangent}
 
 tangent_stack_type(::Type{P}) where {P} = Stack{tangent_type(P)}
+
+__array_ref_type(::Type{P}) where {P} = Base.RefArray{P, Vector{P}, Nothing}
+
+function tangent_ref_type_ub(::Type{P}) where {P}
+    P === DataType && return __array_ref_type(NoTangent)
+    return isconcretetype(P) ? __array_ref_type(tangent_type(P)) : Base.RefArray
+end
+
+tangent_ref_type_ub(::Type{Type{P}}) where {P} = __array_ref_type(NoTangent)
+
+tangent_ref_type(::Type{P}) where {P} = __array_ref_type(tangent_type(P))

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -63,3 +63,12 @@ end
 Base.eltype(::Stack{T}) where {T} = T
 
 top_ref(x::Stack) = Ref(x.memory, x.position)
+
+function tangent_stack_type_ub(::Type{P}) where {P}
+    P === DataType && return Stack{NoTangent}
+    return isconcretetype(P) ? Stack{P} : Stack
+end
+
+tangent_stack_type_ub(::Type{Type{P}}) where {P} = Stack{NoTangent}
+
+tangent_stack_type(::Type{P}) where {P} = Stack{tangent_type(P)}

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -95,6 +95,13 @@ struct NoTangentRefStack end
 Base.push!(::NoTangentRefStack, ::Any) = nothing
 Base.pop!(::NoTangentRefStack) = NoTangentRef()
 
+
+struct SingletonStack{T} end
+
+Base.push!(::SingletonStack, ::Any) = nothing
+@generated Base.pop!(::SingletonStack{T}) where {T} = T.instance
+
+
 function tangent_stack_type(::Type{P}) where {P}
     P === DataType && return Stack{Any}
     T = tangent_type(P)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -85,6 +85,16 @@ Base.setindex!(::NoTangentRef, ::NoTangent) = nothing
 
 top_ref(::NoTangentStack) = NoTangentRef()
 
+"""
+    NoTangentRefStack
+
+Stack for `NoTangentRef`s.
+"""
+struct NoTangentRefStack end
+
+Base.push!(::NoTangentRefStack, ::Any) = nothing
+Base.pop!(::NoTangentRefStack) = NoTangentRef()
+
 function tangent_stack_type(::Type{P}) where {P}
     P === DataType && return Stack{Any}
     T = tangent_type(P)

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -212,7 +212,8 @@ end
     ))
 
     # If the type is a Union, then take the union type of its arguments.
-    P isa Union && return Union{tangent_type(P.a), tangent_type(P.b)}
+    # P isa Union && return Union{tangent_type(P.a), tangent_type(P.b)}
+    P isa Union && return Any
 
     # If the type is itself abstract, it's tangent could be anything.
     # The same goes for if the type has any undetermined type parameters.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -219,6 +219,9 @@ end
     # The same goes for if the type has any undetermined type parameters.
     (isabstracttype(P) || !isconcretetype(P)) && return Any
 
+    # If the type has no fields, then it's a `NoTangent`.
+    Base.issingletontype(P) && return NoTangent
+
     # Derive tangent type.
     return  (ismutabletype(P) ? MutableTangent : Tangent){backing_type(P)}
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1372,6 +1372,10 @@ function test_union_of_arrays(x::Vector{Float64}, b::Bool)
     return 2z
 end
 
+function test_union_of_types(x::Ref{Union{Type{Float64}, Type{Int}}})
+    return x[]
+end
+
 sr(n) = Xoshiro(n)
 
 function generate_test_functions()
@@ -1441,6 +1445,13 @@ function generate_test_functions()
         (false, :none, (lb=1, ub=1_000), datatype_slot_tester, 1),
         (false, :none, (lb=1, ub=1_000), datatype_slot_tester, 2),
         (false, :none, (lb=1, ub=100_000_000), test_union_of_arrays, randn(5), true),
+        (
+            false,
+            :none,
+            nothing,
+            test_union_of_types,
+            Ref{Union{Type{Float64}, Type{Int}}}(Float64),
+        ),
         (
             false,
             :none,

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -40,7 +40,8 @@ using Taped:
     _typeof,
     get_codual,
     get_tangent_stack,
-    top_ref
+    top_ref,
+    NoTangentRef
 
 using .TestUtils:
     test_rrule!!,

--- a/test/interpreter/reverse_mode_ad.jl
+++ b/test/interpreter/reverse_mode_ad.jl
@@ -59,7 +59,7 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
         @testset "SlotRef cond" begin
             dest = 5
             next_blk = 3
-            cond = SlotRef((zero_codual(true), top_ref(Stack(NoTangent()))))
+            cond = SlotRef((zero_codual(true), NoTangentRef()))
             fwds_inst, bwds_inst = build_coinsts(GotoIfNot, dest, next_blk, cond)
 
             # Test forwards instructions.
@@ -78,7 +78,7 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
         @testset "ConstSlot" begin
             dest = 5
             next_blk = 3
-            cond = ConstSlot((zero_codual(true), top_ref(Stack(NoTangent()))))
+            cond = ConstSlot((zero_codual(true), NoTangentRef()))
             fwds_inst, bwds_inst = build_coinsts(GotoIfNot, dest, next_blk, cond)
 
             # Test forwards instructions.
@@ -105,16 +105,16 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
                     ),
                 ),
                 TypedPhiNode(
-                    SlotRef{Tuple{CoDual{Union{}, NoTangent}, Base.RefValue{NoTangent}}}(),
-                    SlotRef{Tuple{CoDual{Union{}, NoTangent}, Base.RefValue{NoTangent}}}(),
+                    SlotRef{Tuple{CoDual{Union{}, NoTangent}, NoTangentRef}}(),
+                    SlotRef{Tuple{CoDual{Union{}, NoTangent}, NoTangentRef}}(),
                     (),
                     (),
                 ),
                 TypedPhiNode(
-                    SlotRef{Tuple{CoDual{Int, NoTangent}, Base.RefValue{NoTangent}}}(),
-                    SlotRef{Tuple{CoDual{Int, NoTangent}, Base.RefValue{NoTangent}}}(),
+                    SlotRef{Tuple{CoDual{Int, NoTangent}, NoTangentRef}}(),
+                    SlotRef{Tuple{CoDual{Int, NoTangent}, NoTangentRef}}(),
                     (1, ),
-                    (SlotRef{Tuple{CoDual{Int, NoTangent}, Base.RefValue{NoTangent}}}(),), # undef element
+                    (SlotRef{Tuple{CoDual{Int, NoTangent}, NoTangentRef}}(),), # undef element
                 ),
             )
             next_blk = 0
@@ -129,8 +129,8 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
             @test nodes[1].ret_slot[] == nodes[1].tmp_slot[]
             @test !isassigned(nodes[2].tmp_slot)
             @test !isassigned(nodes[2].ret_slot)
-            @test !isassigned(nodes[3].tmp_slot)
-            @test !isassigned(nodes[3].ret_slot)
+            @test nodes[3].tmp_slot[] == nodes[3].values[1][]
+            @test nodes[3].ret_slot[] == nodes[3].tmp_slot[]
 
             # Test backwards instructions.
             @test bwds_inst isa Taped.BwdsInst
@@ -189,7 +189,7 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
     @testset "QuoteNode and literals" for (x, out, next_blk) in Any[
         (
             ConstSlot(CoDual(5, NoTangent())),
-            SlotRef{Tuple{CoDual{Int, NoTangent}, array_ref_type(NoTangent)}}(),
+            SlotRef{Tuple{CoDual{Int, NoTangent}, NoTangentRef}}(),
             5,
         ),
     ]
@@ -206,7 +206,7 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
     end
 
     @testset "Expr(:boundscheck)" begin
-        val_ref = SlotRef{Tuple{codual_type(Bool), array_ref_type(NoTangent)}}()
+        val_ref = SlotRef{Tuple{codual_type(Bool), NoTangentRef}}()
         next_blk = 3
         fwds_inst, bwds_inst = build_coinsts(Val(:boundscheck), val_ref, next_blk)
 
@@ -238,20 +238,20 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
             3,
         ),
         (
-            SlotRef{Tuple{codual_type(Int), array_ref_type(NoTangent)}}(),
+            SlotRef{Tuple{codual_type(Int), NoTangentRef}}(),
             (
                 ConstSlot((zero_codual(+), top_ref(Stack(zero_tangent(+))))),
-                ConstSlot((zero_codual(4), top_ref(Stack(NoTangent())))),
-                ConstSlot((zero_codual(5), top_ref(Stack(NoTangent())))),
+                ConstSlot((zero_codual(4), NoTangentRef())),
+                ConstSlot((zero_codual(5), NoTangentRef())),
             ),
             2,
         ),
         (
             SlotRef{Tuple{codual_type(Float64), array_ref_type(Float64)}}(),    
             (
-                ConstSlot((zero_codual(getfield), top_ref(Stack(zero_tangent(getfield))))),
+                ConstSlot((zero_codual(getfield), NoTangentRef())),
                 SlotRef((zero_codual((5.0, 5)), top_ref(Stack(zero_tangent((5.0, 5)))))),
-                ConstSlot((zero_codual(1), top_ref(Stack(NoTangent())))),
+                ConstSlot((zero_codual(1), NoTangentRef())),
             ),
             3,
         ),

--- a/test/interpreter/reverse_mode_ad.jl
+++ b/test/interpreter/reverse_mode_ad.jl
@@ -172,7 +172,7 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
         ),
         (
             typeof(sin),
-            SlotRef{Tuple{codual_type(typeof(sin)), array_ref_type(tangent_type(typeof(sin)))}}(),
+            SlotRef{Tuple{codual_type(typeof(sin)), NoTangentRef}}(),
             ConstSlot(sin),
             4,
         ),
@@ -264,7 +264,7 @@ array_ref_type(::Type{T}) where {T} = Base.RefArray{T, Vector{T}, Nothing}
     ]
         sig = _typeof(map(primal ∘ get_codual, arg_slots))
         interp = Taped.TInterp()
-        evaluator = Taped.get_evaluator(Taped.MinimalCtx(), sig, interp, false)
+        evaluator = Taped.get_evaluator(Taped.MinimalCtx(), sig, interp, true)
         __rrule!! = Taped.get_rrule!!_evaluator(evaluator)
         pb_stack = Taped.build_pb_stack(__rrule!!, evaluator, arg_slots)
         fwds_inst, bwds_inst = build_coinsts(

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -1,15 +1,28 @@
 @testset "stack" begin
-    s = Stack{Float64}()
-    push!(s, 5.0)
-    @test s.position == 1
-    @test s.memory[1] == 5.0
-    @test length(s) == 1
-    @test !isempty(s)
+    @testset "stack functionality" begin
+        s = Stack{Float64}()
+        push!(s, 5.0)
+        @test s.position == 1
+        @test s.memory[1] == 5.0
+        @test length(s) == 1
+        @test !isempty(s)
 
-    s[] = 6.0
-    @test s[] == 6.0
-    @test pop!(s) == 6.0
-    @test s.position == 0
-    @test length(s) == 0
-    @test isempty(s)
+        s[] = 6.0
+        @test s[] == 6.0
+        @test pop!(s) == 6.0
+        @test s.position == 0
+        @test length(s) == 0
+        @test isempty(s)
+    end
+    @testset "tangent_stack_type" begin
+        @test Taped.tangent_stack_type_ub(Float64) == Stack{Float64}
+        @test Taped.tangent_stack_type_ub(Any) == Stack
+        @test Taped.tangent_stack_type_ub(DataType) == Stack{NoTangent}
+        @test Taped.tangent_stack_type_ub(Type{Float64}) == Stack{NoTangent}
+
+        @test Taped.tangent_stack_type(Float64) == Stack{Float64}
+        @test Taped.tangent_stack_type(Any) == Stack{Any}
+        @test Taped.tangent_stack_type(DataType) == Stack{NoTangent}
+        @test Taped.tangent_stack_type(Type{Float64}) == Stack{NoTangent}
+    end
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -24,5 +24,15 @@
         @test Taped.tangent_stack_type(Any) == Stack{Any}
         @test Taped.tangent_stack_type(DataType) == Stack{NoTangent}
         @test Taped.tangent_stack_type(Type{Float64}) == Stack{NoTangent}
+
+        @test Taped.tangent_ref_type_ub(Float64) == Taped.__array_ref_type(Float64)
+        @test Taped.tangent_ref_type_ub(Any) == Base.RefArray
+        @test Taped.tangent_ref_type_ub(DataType) == Taped.__array_ref_type(NoTangent)
+        @test Taped.tangent_ref_type_ub(Type{Float64}) == Taped.__array_ref_type(NoTangent)
+
+        @test Taped.tangent_ref_type(Float64) == Taped.__array_ref_type(Float64)
+        @test Taped.tangent_ref_type(Any) == Taped.__array_ref_type(Any)
+        @test Taped.tangent_ref_type(DataType) == Taped.__array_ref_type(NoTangent)
+        @test Taped.tangent_ref_type(Type{Float64}) == Taped.__array_ref_type(NoTangent)
     end
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -17,7 +17,7 @@
     @testset "tangent_stack_type" begin
         @test Taped.tangent_stack_type_ub(Float64) == Stack{Float64}
         @test Taped.tangent_stack_type_ub(Any) == Stack
-        @test Taped.tangent_stack_type_ub(DataType) == Stack{NoTangent}
+        @test Taped.tangent_stack_type_ub(DataType) == Stack
         @test Taped.tangent_stack_type_ub(Type{Float64}) == Stack{NoTangent}
 
         @test Taped.tangent_stack_type(Float64) == Stack{Float64}
@@ -27,12 +27,7 @@
 
         @test Taped.tangent_ref_type_ub(Float64) == Taped.__array_ref_type(Float64)
         @test Taped.tangent_ref_type_ub(Any) == Base.RefArray
-        @test Taped.tangent_ref_type_ub(DataType) == Taped.__array_ref_type(NoTangent)
+        @test Taped.tangent_ref_type_ub(DataType) == Base.RefArray
         @test Taped.tangent_ref_type_ub(Type{Float64}) == Taped.__array_ref_type(NoTangent)
-
-        @test Taped.tangent_ref_type(Float64) == Taped.__array_ref_type(Float64)
-        @test Taped.tangent_ref_type(Any) == Taped.__array_ref_type(Any)
-        @test Taped.tangent_ref_type(DataType) == Taped.__array_ref_type(NoTangent)
-        @test Taped.tangent_ref_type(Type{Float64}) == Taped.__array_ref_type(NoTangent)
     end
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -15,19 +15,16 @@
         @test isempty(s)
     end
     @testset "tangent_stack_type" begin
-        @test Taped.tangent_stack_type_ub(Float64) == Stack{Float64}
-        @test Taped.tangent_stack_type_ub(Any) == Stack
-        @test Taped.tangent_stack_type_ub(DataType) == Stack
-        @test Taped.tangent_stack_type_ub(Type{Float64}) == Stack{NoTangent}
-
         @test Taped.tangent_stack_type(Float64) == Stack{Float64}
+        @test Taped.tangent_stack_type(Int) == Taped.NoTangentStack
         @test Taped.tangent_stack_type(Any) == Stack{Any}
-        @test Taped.tangent_stack_type(DataType) == Stack{NoTangent}
-        @test Taped.tangent_stack_type(Type{Float64}) == Stack{NoTangent}
+        @test Taped.tangent_stack_type(DataType) == Taped.NoTangentStack
+        @test Taped.tangent_stack_type(Type{Float64}) == Taped.NoTangentStack
 
         @test Taped.tangent_ref_type_ub(Float64) == Taped.__array_ref_type(Float64)
-        @test Taped.tangent_ref_type_ub(Any) == Base.RefArray
-        @test Taped.tangent_ref_type_ub(DataType) == Base.RefArray
-        @test Taped.tangent_ref_type_ub(Type{Float64}) == Taped.__array_ref_type(NoTangent)
+        @test Taped.tangent_ref_type_ub(Int) == Taped.NoTangentRef
+        @test Taped.tangent_ref_type_ub(Any) == Ref
+        @test Taped.tangent_ref_type_ub(DataType) == Ref
+        @test Taped.tangent_ref_type_ub(Type{Float64}) == Taped.NoTangentRef
     end
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -18,7 +18,7 @@
         @test Taped.tangent_stack_type(Float64) == Stack{Float64}
         @test Taped.tangent_stack_type(Int) == Taped.NoTangentStack
         @test Taped.tangent_stack_type(Any) == Stack{Any}
-        @test Taped.tangent_stack_type(DataType) == Taped.NoTangentStack
+        @test Taped.tangent_stack_type(DataType) == Stack{Any}
         @test Taped.tangent_stack_type(Type{Float64}) == Taped.NoTangentStack
 
         @test Taped.tangent_ref_type_ub(Float64) == Taped.__array_ref_type(Float64)

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -3,7 +3,7 @@
     # Each tuple is of the form (primal, t1, t2, increment!!(t1, t2)).
     @testset "$(typeof(p))" for (p, x, y, z) in vcat(
         [
-            (sin, Tangent((;)), Tangent((;)), Tangent((;))),
+            (sin, NoTangent(), NoTangent(), NoTangent()),
             map(Float16, (5.0, 4.0, 3.1, 7.1)),
             (5f0, 4f0, 3f0, 7f0),
             (5.1, 4.0, 3.0, 7.0),


### PR DESCRIPTION
Currently there are a lot of tangent stacks floating around that don't need to exist because they provably contain `NoTangent` elements, so there's really nothing to do with them.

This PR first will tidy up some of the functionality associated with specifying the tangent types of stacks, then go on to replace the usual stacks with a zero-overhead data structure to handle `NoTangent`s. This will improve performance by reducing the work that must be done at instructions associated to non-differentiable outputs, and at call sites with some non-differentiable arguments.

This PR will need to be followed up by another PR which makes more things have a `NoTangent` tangent type, or which allows more than one thing to represent the non-presence of a tangent (e.g. a maybe any singleton type should have this optimisation)