### PR TITLE
Cache Rules in AbstractInterpreter

### DIFF
--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -444,6 +444,9 @@ end
 
 function build_rrule!!(in_f::InterpretedFunction{sig}) where {sig}
 
+    # If we've already constructed this interpreted function, just return it.
+    sig in keys(in_f.interp.in_f_rrule_cache) && return in_f.interp.in_f_rrule_cache[sig]
+
     return_slot = SlotRef{codual_type(eltype(in_f.return_slot))}()
     return_tangent_slot = SlotRef{tangent_type(eltype(in_f.return_slot))}()
     arg_info = make_codual_arginfo(in_f.arg_info)
@@ -471,6 +474,8 @@ function build_rrule!!(in_f::InterpretedFunction{sig}) where {sig}
 
     # Set PhiNodes.
     make_phi_instructions!(in_f, __rrule!!)
+
+    in_f.interp.in_f_rrule_cache[sig] = __rrule!!
 
     return __rrule!!
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1402,6 +1402,10 @@ end
 
 sr(n) = Xoshiro(n)
 
+@noinline function test_self_reference(a, b)
+    return a < b ? a * b : test_self_reference(b, a)
+end
+
 function generate_test_functions()
     return Any[
         (false, :allocs, nothing, const_tester),
@@ -1477,6 +1481,8 @@ function generate_test_functions()
             test_union_of_types,
             Ref{Union{Type{Float64}, Type{Int}}}(Float64),
         ),
+        (false, :allocs, nothing, test_self_reference, 1.1, 1.5),
+        (false, :allocs, nothing, test_self_reference, 1.5, 1.1),
         (
             false,
             :none,


### PR DESCRIPTION
If a rule has already been derived, don't re-derived it, just look it up from a cache of rules.