### PR TITLE
Eager Instruction Creation

### DIFF
--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -588,6 +588,8 @@ end
 # swapfield!
 # throw
 
+Taped._eval(::typeof(throw), args...) = println("throwing :(")
+
 function rrule!!(::CoDual{typeof(tuple)}, args...)
     y = CoDual(tuple(map(primal, args)...), tuple(map(tangent, args)...))
     tuple_pullback(dy, ::NoTangent, dargs...) = NoTangent(), map(increment!!, dargs, dy)...

--- a/src/rrules/foreigncall.jl
+++ b/src/rrules/foreigncall.jl
@@ -473,6 +473,12 @@ function rrule!!(
     return zero_codual(hash(primal(s), primal(h))), NoPullback()
 end
 
+@is_primitive MinimalCtx Tuple{typeof(rethrow)}
+Taped._eval(::typeof(rethrow)) = println("rethrowing")
+
+@is_primitive MinimalCtx Tuple{typeof(rethrow), Any}
+Taped._eval(::typeof(rethrow), x) = println("rethrowing $x")
+
 function unexepcted_foreigncall_error(name)
     throw(error(
         "AD has hit a :($name) ccall. This should not happen. " *

--- a/src/rrules/misc.jl
+++ b/src/rrules/misc.jl
@@ -26,6 +26,10 @@ for name in [
     :(LinearAlgebra.chkstride1),
     :(Threads.nthreads),
     :(Base.depwarn),
+    :(Base.is_root_module),
+    :print,
+    :(Base.compile),
+    :(Base.PCRE.exec)
 ]
     @eval @is_primitive DefaultCtx Tuple{typeof($name), Vararg}
     @eval function rrule!!(::CoDual{_typeof($name)}, args::CoDual...)


### PR DESCRIPTION
At present, the instructions are constructed when-needed. This is helpful for avoiding things which are a little awkward to construct, but has a run-time hit associated to checking whether each instruction is / is-not assigned each time it is encountered.

This PR will attempt to modify this. It necessarily taxes the robustness of our system further, because it requires that _any_ instruction we encounter can be constructed. The basic tests pass locally for the interpreted function as-is, so I'm opening this PR to see whether the integration tests also pass. Presumably they won't.