### PR TITLE
Fix Recursion and add test

### DIFF
--- a/src/interpreter/interpreted_function.jl
+++ b/src/interpreter/interpreted_function.jl
@@ -476,9 +476,6 @@ explosion of types. Moreover, type-stability it maintained.
 """
 function InterpretedFunction(ctx::C, sig::Type{<:Tuple}, interp) where {C}
 
-    # If we've already constructed this interpreted function, just return it.
-    sig in keys(interp.in_f_cache) && return interp.in_f_cache[sig]
-
     # Grab code associated to this function.
     output = Base.code_ircode_by_type(sig; interp)
     if isempty(output)
@@ -522,7 +519,6 @@ function InterpretedFunction(ctx::C, sig::Type{<:Tuple}, interp) where {C}
     make_phi_instructions!(in_f)
 
     # Cache this InterpretedFunction so that we don't have tobuild it again.
-    interp.in_f_cache[sig] = in_f
     return in_f
 end
 

--- a/src/interpreter/reverse_mode_ad.jl
+++ b/src/interpreter/reverse_mode_ad.jl
@@ -444,9 +444,6 @@ end
 
 function build_rrule!!(in_f::InterpretedFunction{sig}) where {sig}
 
-    # If we've already constructed this interpreted function, just return it.
-    sig in keys(in_f.interp.in_f_rrule_cache) && return in_f.interp.in_f_rrule_cache[sig]
-
     return_slot = SlotRef{codual_type(eltype(in_f.return_slot))}()
     return_tangent_slot = SlotRef{tangent_type(eltype(in_f.return_slot))}()
     arg_info = make_codual_arginfo(in_f.arg_info)
@@ -474,8 +471,6 @@ function build_rrule!!(in_f::InterpretedFunction{sig}) where {sig}
 
     # Set PhiNodes.
     make_phi_instructions!(in_f, __rrule!!)
-
-    in_f.interp.in_f_rrule_cache[sig] = __rrule!!
 
     return __rrule!!
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1403,7 +1403,12 @@ end
 sr(n) = Xoshiro(n)
 
 @noinline function test_self_reference(a, b)
-    return a < b ? a * b : test_self_reference(b, a)
+    return a < b ? a * b : test_self_reference(b, a) + a
+end
+
+@noinline function test_recursive_sum(x::Vector{Float64})
+    isempty(x) && return 0.0
+    return @inbounds x[1] + test_recursive_sum(x[2:end])
 end
 
 function generate_test_functions()
@@ -1483,6 +1488,7 @@ function generate_test_functions()
         ),
         (false, :allocs, nothing, test_self_reference, 1.1, 1.5),
         (false, :allocs, nothing, test_self_reference, 1.5, 1.1),
+        (false, :none, nothing, test_recursive_sum, randn(2)),
         (
             false,
             :none,


### PR DESCRIPTION
Because I wasn't properly testing recursion, it was badly broken. The simplest fix by far is to drop caching of rules.

This is a little bit sad, but only a little bit -- rule caching wasn't adding a lot, and was more of a nice-to-have than something that's really important. Certainly, I can't imagine a situation where users are likely to see any runtime difference in performance due to caching.

On the other hand, removing caching removes complexity, and means that we have to worry about less state related stuff.