### PR TITLE
ChainRules Macro

### DIFF
--- a/ext/TapedSpecialFunctionsExt.jl
+++ b/ext/TapedSpecialFunctionsExt.jl
@@ -1,16 +1,10 @@
 module TapedSpecialFunctionsExt
 
-    using ChainRulesCore, SpecialFunctions, Taped
+    using SpecialFunctions, Taped
 
-    import Taped: CoDual, rrule!!, @is_primitive, DefaultCtx
+    import Taped: @from_rrule, DefaultCtx
 
-    @is_primitive DefaultCtx Tuple{typeof(erfc), Float64}
-    function rrule!!(::CoDual{typeof(erfc)}, x::CoDual{Float64})
-        y, erfc_pb = rrule(erfc, primal(x))
-        function erfc_pb!!(dy, df, dx)
-            _, dx_inc = erfc_pb(dy)
-            return df, increment!!(dx, dx_inc)
-        end
-        return zero_codual(y), erfc_pb!!
-    end
+    @from_rrule DefaultCtx Tuple{typeof(airyai), Float64}
+    @from_rrule DefaultCtx Tuple{typeof(airyaix), Float64}
+    @from_rrule DefaultCtx Tuple{typeof(erfc), Float64}
 end

--- a/src/Taped.jl
+++ b/src/Taped.jl
@@ -11,6 +11,8 @@ using
     Random,
     Setfield
 
+import ChainRulesCore
+
 using Base:
     IEEEFloat, unsafe_convert, unsafe_pointer_to_objref, pointer_from_objref, arrayref,
     arrayset
@@ -50,6 +52,8 @@ include(joinpath("rrules", "lapack.jl"))
 include(joinpath("rrules", "low_level_maths.jl"))
 include(joinpath("rrules", "misc.jl"))
 include(joinpath("rrules", "new.jl"))
+
+include("chain_rules_macro.jl")
 
 export
     primal,

--- a/src/chain_rules_macro.jl
+++ b/src/chain_rules_macro.jl
@@ -1,0 +1,80 @@
+__increment_shim!!(::NoTangent, ::ChainRulesCore.NoTangent) = NoTangent()
+__increment_shim!!(x, y) = increment!!(x, y)
+
+"""
+    @from_rrule ctx sig
+
+Creates a `Taped.rrule!!` from a `ChainRulesCore.rrule`. `ctx` is the type of the context in
+which this rule should apply, and `sig` is the type-tuple which specifies which primal the
+rule should apply to.
+
+For example,
+```julia
+@from_rrule DefaultCtx Tuple{typeof(sin), Float64}
+```
+would define a `Taped.rrule!!` for `sin` of `Float64`s, by calling `ChainRulesCore.rrule`.
+
+Health warning:
+Use this function with care. It has only been tested for `Float64` arguments and arguments
+whose `tangent_type` is `NoTangent`, and it is entirely probable that it won't work for
+arguments which aren't `Float64` or non-differentiable.
+
+You should definitely make use of `TestUtils.test_rrule!!` to verify that the rule created
+works as intended.
+"""
+macro from_rrule(ctx, sig)
+
+    @assert sig.head == :curly
+    @assert sig.args[1] == :Tuple
+    arg_type_symbols = sig.args[2:end]
+
+    arg_names = map(n -> Symbol("x_$n"), eachindex(arg_type_symbols))
+    arg_types = map(t -> :(Taped.CoDual{<:$t}), arg_type_symbols)
+    arg_exprs = map((n, t) -> :($n::$t), arg_names, arg_types)
+
+    call_rrule = Expr(
+        :call,
+        :(Taped.ChainRulesCore.rrule),
+        map(n -> :(Taped.primal($n)), arg_names)...,
+    )
+
+    pb_arg_names = map(n -> Symbol("dx_$(n)"), eachindex(arg_names))
+    pb_output_names = map(n -> Symbol("dx_$(n)_inc"), eachindex(arg_names))
+
+    call_pb = Expr(:(=), Expr(:tuple, pb_output_names...), :(pb(dy)))
+    incrementers = Expr(
+        :tuple,
+        map(pb_arg_names, pb_output_names) do a, b
+            :(Taped.__increment_shim!!($a, $b))
+        end...,
+    )
+
+    pb = ExprTools.combinedef(Dict(
+        :head => :function,
+        :name => :pb!!,
+        :args => [:dy, pb_arg_names...],
+        :body => quote
+            $call_pb
+            return $incrementers
+        end,
+    ))
+
+    rule_expr = ExprTools.combinedef(
+        Dict(
+            :head => :function,
+            :name => :(Taped.rrule!!),
+            :args => arg_exprs,
+            :body => quote
+                y, pb = $call_rrule
+                $pb
+                return Taped.zero_codual(y), pb!!
+            end,
+        )
+    )
+
+    ex = quote
+        Taped.is_primitive(::Type{$ctx}, ::Type{$sig}) = true
+        $rule_expr
+    end
+    return esc(ex)
+end

--- a/test/chain_rules_macro.jl
+++ b/test/chain_rules_macro.jl
@@ -1,0 +1,11 @@
+bleh(x::Float64, y::Int) = x * y
+
+function ChainRulesCore.rrule(::typeof(bleh), x::Float64, y::Int)
+    return x * y, dz -> (ChainRulesCore.NoTangent(), dz * y, ChainRulesCore.NoTangent())
+end
+
+Taped.@from_rrule DefaultCtx Tuple{typeof(bleh), Float64, Int}
+
+@testset "chain_rules_macro" begin
+    Taped.TestUtils.test_rrule!!(Xoshiro(1), bleh, 5.0, 4; perf_flag=:stability)
+end

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -11,6 +11,8 @@ using
     Taped,
     Test
 
+import ChainRulesCore
+
 using Base: unsafe_load, pointer_from_objref
 using Base.Iterators: product
 using Core:

--- a/test/integration_testing/special_functions.jl
+++ b/test/integration_testing/special_functions.jl
@@ -1,5 +1,11 @@
 @testset "special_functions" begin
     @testset for (interface_only, perf_flag, f, x...) in [
+        (false, :stability, airyai, 0.1),
+        (false, :stability, airyai, 0.0),
+        (false, :stability, airyai, -0.5),
+        (false, :stability, airyaix, 0.1),
+        (false, :stability, airyaix, 0.05),
+        (false, :stability, airyaix, 0.9),
         (false, :stability, erfc, 0.1),
         (false, :stability, erfc, 0.0),
         (false, :stability, erfc, -0.5),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ include("front_matter.jl")
             @info "new"
             include(joinpath("rrules", "new.jl"))
         end
+        include("chain_rules_macro.jl")
     elseif test_group == "integration_testing/misc"
         include(joinpath("integration_testing/", "misc.jl"))
         include(joinpath("integration_testing", "battery_tests.jl"))


### PR DESCRIPTION
Adds a macro to make creating `rrule!!`s from `rrule`s straightforward. Use it to include a few more SpecialFunctions rules.