### PR TITLE
Use 1.10 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: '1'
           arch: x64
-          include-all-prereleases: true
+          include-all-prereleases: false
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
@@ -76,7 +76,7 @@ jobs:
         with:
           version: '1'
           arch: x64
-          include-all-prereleases: true
+          include-all-prereleases: false
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - run: mkdir bench_results


### PR DESCRIPTION
CI was using the latest release (because at some point in the past I needed to use a 1.10 pre-release). Unfortunately, some dependencies don't yet work on 1.11-alpha, so this breaks CI. This PR restricts CI to run on the latest patch version of 1.10.