### PR TITLE
Set version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Taped"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt and contributors"]
-version = "1.0.0-DEV"
+version = "0.1.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
It will be helpful to have a version of the package registered in order to get it working with the various AD interface packages, so I'm setting the version to pre-1.0 so that we can get going with that.